### PR TITLE
Add CI GitHub Action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,20 @@
+name: Continuous Integration Testing
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+jobs:
+  Maven-Verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
+      - name: Run the Maven verify phase
+        run: mvn --batch-mode --update-snapshots verify

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It uses [schxslt](https://github.com/schxslt/schxslt) and [Saxon-HE](https://sax
 
 ## Limitations
 
+* Requires Java 11
 * You can only validate with local `.sch` files
 * Not tested thoroughly
 * The `.jar` is prohibitively large to include as a part of the standard LemMinX distribution

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <junit.version>5.7.1</junit.version>
     <lemminx.version>0.20.0</lemminx.version>
   </properties>


### PR DESCRIPTION
Needs to run on Java 11 due to Jetty. As such, I updated the settings for the Maven compiler plugin to target Java 11.
