### PR TITLE
Update to lemminx 0.29.0

### DIFF
--- a/.project
+++ b/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1620240553949</id>
+			<id>1739305037495</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "java.test.config": {
+    "vmArgs": [
+      "-noverify"
+    ]
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <junit.version>5.11.4</junit.version>
-    <lemminx.version>0.20.0</lemminx.version>
+    <lemminx.version>0.29.0</lemminx.version>
   </properties>
 
   <repositories>
@@ -46,19 +46,7 @@
     <!-- Test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -127,19 +115,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.3.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-          </dependency>
-        </dependencies>
+        <version>3.5.1</version>
+        <configuration>
+          <argLine>-noverify</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/github/datho7561/common/ContentModelManagerManager.java
+++ b/src/main/java/com/github/datho7561/common/ContentModelManagerManager.java
@@ -29,7 +29,17 @@ public class ContentModelManagerManager {
 	private ContentModelManager contentModelManager = null;
 	private List<Consumer<ContentModelManager>> contentModelManagerListeners;
 
-	public ContentModelManagerManager(XMLExtensionsRegistry registry) {
+	private static ContentModelManagerManager INSTANCE;
+
+	public static ContentModelManagerManager getInstance(XMLExtensionsRegistry registry) {
+		if (INSTANCE != null) {
+			return INSTANCE;
+		}
+		INSTANCE = new ContentModelManagerManager(registry);
+		return INSTANCE;
+	}
+
+	private ContentModelManagerManager(XMLExtensionsRegistry registry) {
 		this.registry = registry;
 		this.contentModelManagerListeners = new ArrayList<>();
 	}
@@ -52,6 +62,7 @@ public class ContentModelManagerManager {
 		for (Consumer<ContentModelManager> listener : contentModelManagerListeners) {
 			listener.accept(contentModelManager);
 		}
+		contentModelManagerListeners = null;
 		return contentModelManager;
 	}
 
@@ -61,7 +72,6 @@ public class ContentModelManagerManager {
 			return;
 		}
 		contentModelManagerListeners.add(fn);
-		contentModelManagerListeners = null;
 	}
 
 }

--- a/src/main/java/com/github/datho7561/schematron/SchematronModelProvider.java
+++ b/src/main/java/com/github/datho7561/schematron/SchematronModelProvider.java
@@ -1,17 +1,29 @@
 package com.github.datho7561.schematron;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.dom.XMLModel;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelProvider;
+import org.eclipse.lemminx.uriresolver.URIResolverExtensionManager;
 import org.eclipse.lsp4j.LocationLink;
 
 public class SchematronModelProvider implements ContentModelProvider {
+
+	public static final String SCHEMATRON_XML_MODEL_BINDING_KIND = "schematron-xml-model";
+
+	private final URIResolverExtensionManager resolverExtensionManager;
+
+	public SchematronModelProvider(URIResolverExtensionManager resolverExtensionManager) {
+		this.resolverExtensionManager = resolverExtensionManager;
+	}
 
 	public static class SchematronCMDocument implements CMDocument {
 
@@ -44,7 +56,10 @@ public class SchematronModelProvider implements ContentModelProvider {
 
 	@Override
 	public boolean adaptFor(DOMDocument document, boolean internal) {
-		return adaptFor(document.getBaseURI());
+		if (internal) {
+			return false;
+		}
+		return document.getXMLModels().stream().anyMatch(SchematronModelProvider::isApplicable);
 	}
 
 	@Override
@@ -54,7 +69,17 @@ public class SchematronModelProvider implements ContentModelProvider {
 
 	@Override
 	public Collection<Identifier> getIdentifiers(DOMDocument xmlDocument, String namespaceURI) {
-		return null;
+		List<XMLModel> xmlModels = xmlDocument.getXMLModels();
+		if (xmlModels.isEmpty()) {
+			return Collections.emptyList();
+		}
+		Collection<Identifier> identifiers = new ArrayList<>();
+		for (XMLModel xmlModel : xmlModels) {
+			if (isApplicable(xmlModel)) {
+				identifiers.add(new Identifier(null, xmlModel.getHref(), xmlModel.getHrefNode(), SCHEMATRON_XML_MODEL_BINDING_KIND));
+			}
+		}
+		return identifiers;
 	}
 
 	@Override
@@ -67,5 +92,12 @@ public class SchematronModelProvider implements ContentModelProvider {
 		return new SchematronCMDocument();
 	}
 
+	private static boolean isApplicable(XMLModel xmlModel) {
+		String href = xmlModel.getHref();
+		if (href == null) {
+			return false;
+		}
+		return href.endsWith(".sch");
+	}
 
 }

--- a/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
+++ b/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
@@ -40,8 +40,8 @@ public class SchematronPlugin implements IXMLExtension {
 		diagnosticsParticipant = new SchematronDiagnosticsParticipant(registry);
 		registry.registerDiagnosticsParticipant(diagnosticsParticipant);
 
-		ContentModelProvider modelProvider = new SchematronModelProvider();
-		contentModelManagerManager = new ContentModelManagerManager(registry);
+		ContentModelProvider modelProvider = new SchematronModelProvider(registry.getResolverExtensionManager());
+		contentModelManagerManager = ContentModelManagerManager.getInstance(registry);
 		contentModelManagerManager.registerContentModelListener((cm) -> {
 			cm.registerModelProvider(modelProvider);
 		});


### PR DESCRIPTION
It seems that, while the function signatures haven't changed, there were some API changes during the implementation of RelaxNG support (likely for the better). I adapted to these changes to get the tests passing again.

We need to use `-noverify` in tests, because lemminx adds classes into the jing packages in order to access some package private stuff. (this breaks jar signing angry, which `-noverify` silences).

It should be fine for the built .jar, since we remove all the signatures during shading.