### PR TITLE
Recover after failed 0.1.0 release

### DIFF
--- a/vscode-schematron/.gitignore
+++ b/vscode-schematron/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-jars
+jars/*.jar
 dist
 out
 .vscode-test

--- a/vscode-schematron/.vscodeignore
+++ b/vscode-schematron/.vscodeignore
@@ -12,3 +12,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+jars/.gitkeep

--- a/vscode-schematron/README.md
+++ b/vscode-schematron/README.md
@@ -54,7 +54,7 @@ You can associate this schema to your XML document using the `<?xml-model ...?>`
 
 You will get validation based on the Schematron rules:
 
-![Validation for the XML Document against the schema. The assertion error: "If the honourific "Mr" is used, the gender must be "Male"." appears](./images/validation.png)
+![Validation for the XML Document against the schema. The assertion error: "The size must be S, M, L, or XL, or a number between 0 and 30." appears](./images/validation.png)
 
 ## Requirements
 


### PR DESCRIPTION
- Fix alt text for demo error message image in vscode extension readme
- Add `jars` folder to fix extension packaging error