### PR TITLE
Associate Schematron `.rnc` schema with XML files

### DIFF
--- a/lemminx-schematron/.vscode/settings.json
+++ b/lemminx-schematron/.vscode/settings.json
@@ -4,5 +4,6 @@
     "vmArgs": [
       "-noverify"
     ]
-  }
+  },
+  "java.compile.nullAnalysis.mode": "disabled"
 }

--- a/lemminx-schematron/pom.xml
+++ b/lemminx-schematron/pom.xml
@@ -97,6 +97,28 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+        <executions>
+          <!-- Download copies of all transitive dependencies, then remove all jarsigner signatures
+          from those dependencies. This is needed to prevent the classloader from complaining about
+          lemminx adding classes into the jing packages, which causes problems when attempting to
+          use the RelaxNG features (sometimes failing silently!) -->
+          <execution>
+            <id>unpack-dependencies</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA</excludes>
+              <outputDirectory>${project.build.directory}/designatured</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.6.0</version>
         <executions>
@@ -149,6 +171,14 @@
         <version>3.5.2</version>
         <configuration>
           <argLine>-noverify</argLine>
+          <!-- use the copies of the dependencies that have the jarsignatures removed in order to prevent the
+          classloader from throwing an error because lemminx adds classes into the jing package. -->
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.build.directory}/designatured</additionalClasspathElement>
+          </additionalClasspathElements>
+          <classpathDependencyScopeExclude>compile</classpathDependencyScopeExclude>
+          <classpathDependencyScopeExclude>runtime</classpathDependencyScopeExclude>
+          <classpathDependencyScopeExclude>test</classpathDependencyScopeExclude>
         </configuration>
       </plugin>
     </plugins>

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Constants.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Constants.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561.schematron;
+
+/**
+ * String constants related to Schematron.
+ */
+public class Constants {
+	public static final String SCHEMATRON_NAMESPACE_URI = "http://purl.oclc.org/dsdl/schematron";
+
+	// https://github.com/Schematron/schema
+	public static final String SCHEMATRON_RNC = "https://raw.githubusercontent.com/Schematron/schema/refs/heads/main/schematron.rnc";
+}

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronMetaschemaResolverParticipant.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronMetaschemaResolverParticipant.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561.schematron;
+
+import org.eclipse.lemminx.uriresolver.CacheResourcesManager;
+import org.eclipse.lemminx.uriresolver.CacheResourcesManager.ResourceToDeploy;
+import org.eclipse.lemminx.uriresolver.URIResolverExtension;
+
+/**
+ * URI resolver for the rnc-based metaschema for Schematron.
+ */
+public class SchematronMetaschemaResolverParticipant implements URIResolverExtension {
+
+	private static final ResourceToDeploy SCHEMATRON_METASCHEMA_RESOURCE = new ResourceToDeploy(Constants.SCHEMATRON_RNC,
+			"schemas/schematron.rnc");
+
+	@Override
+	public String resolve(String baseLocation, String publicId, String systemId) {
+		if (!Constants.SCHEMATRON_NAMESPACE_URI.equals(publicId)) {
+			return null;
+		}
+		try {
+			return CacheResourcesManager.getResourceCachePath(SCHEMATRON_METASCHEMA_RESOURCE).toFile().toURI().toString();
+		} catch (Exception e) {
+			// Do nothing?
+		}
+		return Constants.SCHEMATRON_RNC;
+	}
+
+	@Override
+	public String getName() {
+		return "schematron metaschema";
+	}
+
+}

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronModelProvider.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronModelProvider.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
 package com.github.datho7561.schematron;
 
 import java.util.ArrayList;

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
@@ -15,6 +15,7 @@ import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
 import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lemminx.uriresolver.URIResolverExtension;
 
 import com.github.datho7561.common.ContentModelManagerManager;
 
@@ -28,6 +29,7 @@ import com.github.datho7561.common.ContentModelManagerManager;
 public class SchematronPlugin implements IXMLExtension {
 
 	private IDiagnosticsParticipant diagnosticsParticipant;
+	private URIResolverExtension metaschemaRncURIResolverParticipant;
 	private ContentModelManagerManager contentModelManagerManager;
 
 	@Override
@@ -39,6 +41,8 @@ public class SchematronPlugin implements IXMLExtension {
 	public void start(InitializeParams params, XMLExtensionsRegistry registry) {
 		diagnosticsParticipant = new SchematronDiagnosticsParticipant(registry);
 		registry.registerDiagnosticsParticipant(diagnosticsParticipant);
+		metaschemaRncURIResolverParticipant = new SchematronMetaschemaResolverParticipant();
+		registry.getResolverExtensionManager().registerResolver(metaschemaRncURIResolverParticipant);
 
 		ContentModelProvider modelProvider = new SchematronModelProvider();
 		contentModelManagerManager = ContentModelManagerManager.getInstance(registry);
@@ -50,6 +54,7 @@ public class SchematronPlugin implements IXMLExtension {
 	@Override
 	public void stop(XMLExtensionsRegistry registry) {
 		registry.unregisterDiagnosticsParticipant(diagnosticsParticipant);
+		registry.getResolverExtensionManager().unregisterResolver(metaschemaRncURIResolverParticipant);
 	}
 
 }

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Utils.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Utils.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561.schematron;
+
+/**
+ * Utility methods.
+ */
+public class Utils {
+
+	public static final boolean isSchematronURI(String uri) {
+		return uri.endsWith(".sch");
+	}
+
+}

--- a/lemminx-schematron/src/main/resources/schemas/schematron.rnc
+++ b/lemminx-schematron/src/main/resources/schemas/schematron.rnc
@@ -1,0 +1,221 @@
+# Copyright © ISO/IEC 2017
+# The following permission notice and disclaimer shall be included in all
+# copies of this XML schema ("the Schema"), and derivations of the Schema:
+
+# Permission is hereby granted, free of charge in perpetuity, to any
+# person obtaining a copy of the Schema, to use, copy, modify, merge and
+# distribute free of charge, copies of the Schema for the purposes of
+# developing, implementing, installing and using software based on the
+# Schema, and to permit persons to whom the Schema is furnished to do so,
+# subject to the following conditions:
+
+# THE SCHEMA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SCHEMA OR THE USE OR
+# OTHER DEALINGS IN THE SCHEMA.
+
+# In addition, any modified copy of the Schema shall include the following
+# notice:
+
+# "THIS SCHEMA HAS BEEN MODIFIED FROM THE SCHEMA DEFINED IN ISO/IEC 19757 3,
+# AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD".
+
+namespace local = ""
+default namespace sch = "http://purl.oclc.org/dsdl/schematron"
+
+start = schema
+
+# Element declarations
+schema =
+    element schema {
+        attribute id { xsd:ID }?,
+        rich,
+        attribute schemaVersion { non-empty-string }?,
+        attribute defaultPhase { xsd:IDREF }?,
+        attribute queryBinding { non-empty-string }?,
+        (foreign
+         & inclusion*
+         & (title?, ns*, p*, let*, phase*, pattern+, p*, diagnostics?, properties?))
+    }
+active =
+    element active {
+        attribute pattern { xsd:IDREF },
+        (foreign & (text | dir | emph | span)*)
+    }
+assert =
+    element assert {
+        attribute test { exprValue },
+        attribute flag { flagValue }?,
+        attribute id { xsd:ID }?,
+        attribute diagnostics { xsd:IDREFS }?,
+        attribute properties { xsd:IDREFS }?,
+        rich,
+        linkable,
+        (foreign & (text | name | value-of | emph | dir | span)*)
+    }
+diagnostic =
+    element diagnostic {
+        attribute id { xsd:ID },
+        attribute role { roleValue }?,
+        rich,
+        (foreign & (text | value-of | emph | dir | span)*)
+    }
+diagnostics = element diagnostics { foreign & inclusion* & diagnostic* }
+dir =
+    element dir {
+        attribute value { "ltr" | "rtl" }?,
+        (foreign & text)
+    }
+emph = element emph { text }
+extends =
+    element extends {
+        (attribute rule { xsd:IDREF }
+         | attribute href { uriValue }),
+        foreign-empty
+    }
+let =
+    element let {
+        attribute name { nameValue },
+        (attribute value { string }
+         | foreign-element+)
+    }
+name =
+    element name {
+        attribute path { pathValue }?,
+        foreign-empty
+    }
+ns =
+    element ns {
+        attribute uri { uriValue },
+        attribute prefix { nameValue },
+        foreign-empty
+    }
+p =
+    element p {
+        attribute id { xsd:ID }?,
+        attribute class { classValue }?,
+        attribute icon { uriValue }?,
+        (foreign & (text | dir | emph | span)*)
+    }
+param =
+    element param {
+        attribute name { nameValue },
+        attribute value { non-empty-string }
+    }
+
+pattern =
+    element pattern {
+        attribute documents { pathValue }?,
+        rich,
+        (foreign
+         & inclusion*
+         & ((attribute abstract { "true" },
+             attribute id { xsd:ID },
+             title?,
+             (p*, let*, rule*))
+            | (attribute abstract { "false" }?,
+               attribute id { xsd:ID }?,
+               title?,
+               (p*, let*, rule*))
+            | (attribute abstract { "false" }?,
+               attribute is-a { xsd:IDREF },
+               attribute id { xsd:ID }?,
+               title?,
+               (p*, param*))))
+    }
+phase =
+    element phase {
+        attribute id { xsd:ID },
+        rich,
+        (foreign & inclusion* & (p*, let*, active*))
+    }
+properties = element properties { property* }
+property =
+    element property {
+        attribute id { xsd:ID },
+        attribute role { roleValue }?,
+        attribute scheme { text }?,
+        (foreign & (text | name | value-of | emph | dir | span)*)
+    }
+report =
+    element report {
+        attribute test { exprValue },
+        attribute flag { flagValue }?,
+        attribute id { xsd:ID }?,
+        attribute diagnostics { xsd:IDREFS }?,
+        attribute properties { xsd:IDREFS }?,
+        rich,
+        linkable,
+        (foreign & (text | name | value-of | emph | dir | span)*)
+    }
+rule =
+    element rule {
+        attribute flag { flagValue }?,
+        rich,
+        linkable,
+        (foreign
+         & inclusion*
+         & ((attribute abstract { "true" },
+             attribute id { xsd:ID },
+             let*,
+             (assert | report | extends | p)+)
+            | (attribute context { pathValue },
+               attribute id { xsd:ID }?,
+               attribute abstract { "false" }?,
+               let*,
+               (assert | report | extends | p)+)))
+    }
+span =
+    element span {
+        attribute class { classValue },
+        (foreign & text)
+    }
+title = element title { (text | dir)* }
+value-of =
+    element value-of {
+        attribute select { pathValue },
+        foreign-empty
+    }
+
+# common declarations
+inclusion =
+    element include {
+        attribute href { uriValue },
+        foreign-empty
+    }
+rich =
+    attribute icon { uriValue }?,
+    attribute see { uriValue }?,
+    attribute fpi { fpiValue }?,
+    attribute xml:lang { langValue }?,
+    attribute xml:space { "preserve" | "default" }?
+linkable =
+    attribute role { roleValue }?,
+    attribute subject { pathValue }?
+foreign = foreign-attributes, foreign-element*
+foreign-empty = foreign-attributes
+foreign-attributes = attribute * - (local:* | xml:*) { text }*
+foreign-element =
+    element * - sch:* {
+        (attribute * { text }
+         | foreign-element
+         | schema
+         | text)*
+    }
+
+# Data types
+uriValue = xsd:anyURI
+pathValue = string
+exprValue = string
+fpiValue = string
+langValue = xsd:language
+roleValue = string
+flagValue = string
+nameValue = string
+
+# In the default query language binding, xsd:NCNAME
+classValue = string
+non-empty-string = xsd:token { minLength = "1" }

--- a/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaCompletionTest.java
+++ b/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaCompletionTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561;
+
+import static org.eclipse.lemminx.XMLAssert.CDATA_SNIPPETS;
+import static org.eclipse.lemminx.XMLAssert.COMMENT_SNIPPETS;
+import static org.eclipse.lemminx.XMLAssert.c;
+import static org.eclipse.lemminx.XMLAssert.te;
+
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.jupiter.api.Test;
+
+public class SchematronMetaschemaCompletionTest extends BaseFileTempTest {
+
+	@Test
+	public void testValidationElementAssertion() throws Exception {
+		String xml = "<schema xmlns=\"http://purl.oclc.org/dsdl/schematron\">\n" +
+				"  <pattern>\n" +
+				"    <|\n" +
+				"  </pattern>\n" +
+				"</schema>\n";
+		testCompletionFor(xml, CDATA_SNIPPETS + COMMENT_SNIPPETS + 5, //
+				c("include", te(2, 4, 2, 5, "<include href=\"\"></include>"), "<include"));
+	}
+
+	private static void testCompletionFor(String value, Integer expectedCount, CompletionItem... expectedItems)
+			throws BadLocationException {
+		testCompletionFor(value, false, expectedCount, expectedItems);
+	}
+
+	private static void testCompletionFor(String value, boolean enableItemDefaults, Integer expectedCount,
+			CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(new XMLLanguageService(), value, null, null, "src/test/resources/schematron/test.xml",
+				expectedCount, true, expectedItems);
+	}
+
+}

--- a/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaDiagnosticsTest.java
+++ b/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaDiagnosticsTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561;
+
+import static com.github.datho7561.TestUtils.d;
+import static org.eclipse.lemminx.XMLAssert.r;
+
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.junit.jupiter.api.Test;
+
+public class SchematronMetaschemaDiagnosticsTest extends AbstractCacheBasedTest {
+
+	@Test
+	public void testValidationElementAssertion() {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<schema xmlns=\"http://purl.oclc.org/dsdl/schematron\">\n" + //
+				"  <pattern>\n" + //
+				"    <rupertGrint></rupertGrint>\n" + //
+				"  </pattern>\n" + //
+				"</schema>";
+		XMLAssert.testDiagnosticsFor(xml, d(r(3, 5, 3, 16),
+				"element \"rupertGrint\" not allowed anywhere; expected the element end-tag, element \"include\", \"let\", \"p\", \"rule\" or \"title\" or an element from another namespace", "unknown_element"));
+	}
+
+}

--- a/lemminx-schematron/src/test/resources/META-INF/services/org.eclipse.lemminx.services.extensions.IXMLExtension
+++ b/lemminx-schematron/src/test/resources/META-INF/services/org.eclipse.lemminx.services.extensions.IXMLExtension
@@ -1,1 +1,0 @@
-com.github.datho7561.schematron.SchematronPlugin

--- a/vscode-schematron/.vscode/tasks.json
+++ b/vscode-schematron/.vscode/tasks.json
@@ -1,64 +1,51 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-            "label": "watch",
-            "dependsOn": [
-                "npm: watch:tsc",
-                "npm: watch:esbuild"
-            ],
-            "presentation": {
-                "reveal": "never"
-            },
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
-        },
-        {
-            "type": "npm",
-            "script": "watch:esbuild",
-            "group": "build",
-            "problemMatcher": "$esbuild-watch",
-            "isBackground": true,
-            "label": "npm: watch:esbuild",
-            "presentation": {
-                "group": "watch",
-                "reveal": "never"
-            }
-        },
-		{
-            "type": "npm",
-            "script": "watch:tsc",
-            "group": "build",
-            "problemMatcher": "$tsc-watch",
-            "isBackground": true,
-            "label": "npm: watch:tsc",
-            "presentation": {
-                "group": "watch",
-                "reveal": "never"
-            }
-        },
-		{
-			"type": "npm",
-			"script": "watch-tests",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never",
-				"group": "watchers"
-			},
-			"group": "build"
-		},
-		{
-			"label": "tasks: watch-tests",
-			"dependsOn": [
-				"npm: watch",
-				"npm: watch-tests"
-			],
-			"problemMatcher": []
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "watch",
+      "dependsOn": [
+        "npm: watch:tsc"
+      ],
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "script": "watch:tsc",
+      "group": "build",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "label": "npm: watch:tsc",
+      "presentation": {
+        "group": "watch",
+        "reveal": "never"
+      }
+    },
+    {
+      "type": "npm",
+      "script": "watch-tests",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never",
+        "group": "watchers"
+      },
+      "group": "build"
+    },
+    {
+      "label": "tasks: watch-tests",
+      "dependsOn": [
+        "npm: watch",
+        "npm: watch-tests"
+      ],
+      "problemMatcher": []
+    }
+  ]
 }


### PR DESCRIPTION
I needed to do some ugly Maven hacks in order to get the completion test suite to work. Please refer to the comments to understand what I'm doing. Perhaps I should raise this against LemMinX? It might prevent RelaxNG validation in Eclipse with WildWebDeveloper.

Fixes #2