### PR TITLE
Validate Schematron schemas against `schematron.sch`

### DIFF
--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Constants.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/Constants.java
@@ -17,4 +17,5 @@ public class Constants {
 
 	// https://github.com/Schematron/schema
 	public static final String SCHEMATRON_RNC = "https://raw.githubusercontent.com/Schematron/schema/refs/heads/main/schematron.rnc";
+	public static final String SCHEMATRON_SCH = "https://raw.githubusercontent.com/Schematron/schema/refs/heads/main/schematron.sch";
 }

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronDocumentValidator.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronDocumentValidator.java
@@ -13,12 +13,15 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -27,6 +30,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
@@ -57,9 +61,18 @@ public class SchematronDocumentValidator {
 	// person must be "Male".
 	private static final Pattern SCHEMATRON_MESSAGE_DECODER = Pattern.compile("failed-assert ([^ ]+) (.*)");
 
+	private static final String FAILED_ASSERT_ERROR_CODE = "schematron-failed-assert";
+
+	// schxslt uses this syntax to represent namespaces in xpaths, but in reality they should be expressed as prefixes
+	// (which are provided to the xpath processor through a mechanism other than the path itself).
+	private static final Pattern XPATH_WEIRD_NAMESPACE = Pattern.compile("Q\\{([^}]+)\\}");
+
 	private final XPathFactory xpathFactory = XPathFactory.newInstance();
 
 	private static final Logger LOGGER = Logger.getLogger(SchematronDocumentValidator.class.getName());
+
+	// something nonsense and long so that it doesn't overlap with prefixes that the user is likely to use
+	private static final String FAKE_PREFIX_TO_USE_FOR_DEFAULT_NS = "banananas";
 
 	/**
 	 * Returns a list of diagnostics for an XML document given the Schematron
@@ -109,13 +122,23 @@ public class SchematronDocumentValidator {
 	}
 
 	private Diagnostic getSchematronMessageAsDiagnostic(String message, DOMDocument xmlDocument) {
+		// the message contains the literal text of the <test> element,
+		// which may span several lines
+		message = message.replace("\r\n", "");
+		message = message.replace("\n", "");
 		Diagnostic d = new Diagnostic(ZERO_RANGE, message);
-		d.setCode("failed-assert");
+		d.setCode(FAILED_ASSERT_ERROR_CODE);
 
 		Matcher m = SCHEMATRON_MESSAGE_DECODER.matcher(message);
 		if (m.find()) {
-			d.setMessage(m.group(2));
-			String xpathExpression = getSanitizedXPathExpression(m.group(1));
+			// the message within the <test> element may span multiple lines,
+			// so text on subsequent lines may be indented.
+			// We'll need to clear this up to be legible.
+			String messageText = m.group(2);
+			messageText = messageText.replaceAll("\\s+", " ");
+			messageText = messageText.trim();
+			d.setMessage(messageText);
+			String xpathExpression = getSanitizedXPathExpression(m.group(1), xmlDocument);
 			DOMNode node = getNodeFromXPathExpression(xpathExpression, xmlDocument);
 			try {
 				d.setRange(getRangeFromDOMNode(node, xmlDocument));
@@ -129,6 +152,32 @@ public class SchematronDocumentValidator {
 	private DOMNode getNodeFromXPathExpression(String xpathExpression, DOMDocument xmlDocument) {
 		try {
 			XPath xpath = xpathFactory.newXPath();
+			xpath.setNamespaceContext(new NamespaceContext() {
+
+				@Override
+				public String getNamespaceURI(String prefix) {
+					switch (prefix) {
+						case FAKE_PREFIX_TO_USE_FOR_DEFAULT_NS:
+							return xmlDocument.getDocumentElement().getAttribute("xmlns");
+					}
+					return xmlDocument.getDocumentElement().getAttribute("xmlns:" + prefix);
+				}
+
+				@Override
+				public String getPrefix(String namespaceURI) {
+					return lookupPrefix(xmlDocument, namespaceURI);
+				}
+
+				@Override
+				public Iterator<String> getPrefixes(String namespaceURI) {
+					String prefix = lookupPrefix(xmlDocument, namespaceURI);
+					if (prefix == null) {
+						return Collections.emptyIterator();
+					}
+					return List.of(prefix).iterator();
+				}
+
+			});
 			XPathExpression compiledExpression = xpath.compile(xpathExpression);
 			NodeList nodeList = (NodeList) compiledExpression.evaluate(xmlDocument, XPathConstants.NODESET);
 			if (nodeList.getLength() > 0) {
@@ -141,9 +190,39 @@ public class SchematronDocumentValidator {
 		return null;
 	}
 
-	private static String getSanitizedXPathExpression(String xpathExpression) {
+	private static String getSanitizedXPathExpression(String xpathExpression, DOMDocument domDocument) {
+
+		// remove the blank namespace for elements with a blank namespace
 		xpathExpression = xpathExpression.replace("Q{}", "");
+
+		// replace the Q{https://example.com/namespace} with the prefix used in root element
+		Matcher m = XPATH_WEIRD_NAMESPACE.matcher(xpathExpression);
+		while (m.find()) {
+			String namespaceUri = m.group(1);
+			String prefix = lookupPrefix(domDocument, namespaceUri);
+			if (prefix != null && prefix.isEmpty()) {
+				xpathExpression = m.replaceFirst(FAKE_PREFIX_TO_USE_FOR_DEFAULT_NS + ":");
+			} else if (prefix != null) {
+				xpathExpression = m.replaceFirst(prefix + ":");
+			} else {
+				xpathExpression = m.replaceFirst("");
+			}
+			m = XPATH_WEIRD_NAMESPACE.matcher(xpathExpression);
+		}
+
 		return xpathExpression.replaceFirst("\\[1\\]", "");
+	}
+
+	private static String lookupPrefix(DOMDocument domDocument, String namespaceUri) {
+		if (namespaceUri.equals(domDocument.getDocumentElement().getAttribute("xmlns"))) {
+			return "";
+		}
+		for (DOMAttr attr : domDocument.getDocumentElement().getAttributeNodes()) {
+			if (namespaceUri.equals(attr.getValue()) && attr.getName().startsWith("xmlns:")) {
+				return attr.getName().substring("xmlns:".length());
+			}
+		}
+		return null;
 	}
 
 	private static Range getRangeFromDOMNode(DOMNode node, DOMDocument xmlDocument) throws BadLocationException {

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronMetaschemaSchDiagnosticsParticipant.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronMetaschemaSchDiagnosticsParticipant.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.datho7561.schematron;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
+import org.eclipse.lemminx.uriresolver.CacheResourcesManager;
+import org.eclipse.lemminx.uriresolver.CacheResourcesManager.ResourceToDeploy;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * Provides diagnostics in Schematron schemas based on the rules in
+ * `schematron.sch` (accessible under the Schematron GitHub organization).
+ */
+public class SchematronMetaschemaSchDiagnosticsParticipant implements IDiagnosticsParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(SchematronMetaschemaSchDiagnosticsParticipant.class.getName());
+
+	private SchematronDocumentValidator validator = new SchematronDocumentValidator();
+
+	private static final ResourceToDeploy SCHEMATRON_METASCHEMA_RESOURCE = new ResourceToDeploy(Constants.SCHEMATRON_SCH,
+			"schemas/schematron.sch");
+
+	@Override
+	public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
+			XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
+		if (!Constants.SCHEMATRON_NAMESPACE_URI.equals(xmlDocument.getNamespaceURI())) {
+			return;
+		}
+		try {
+			diagnostics.addAll(validator.validate(xmlDocument, List.of(CacheResourcesManager.getResourceCachePath(SCHEMATRON_METASCHEMA_RESOURCE).toFile()), cancelChecker));
+		} catch (IOException e) {
+			LOGGER.throwing(SchematronMetaschemaSchDiagnosticsParticipant.class.getName(), "doDiagnostics", e);
+		}
+	}
+
+}

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronPlugin.java
@@ -29,6 +29,7 @@ import com.github.datho7561.common.ContentModelManagerManager;
 public class SchematronPlugin implements IXMLExtension {
 
 	private IDiagnosticsParticipant diagnosticsParticipant;
+	private IDiagnosticsParticipant metaschemaSchDiagnosticsParticipant;
 	private URIResolverExtension metaschemaRncURIResolverParticipant;
 	private ContentModelManagerManager contentModelManagerManager;
 
@@ -41,6 +42,8 @@ public class SchematronPlugin implements IXMLExtension {
 	public void start(InitializeParams params, XMLExtensionsRegistry registry) {
 		diagnosticsParticipant = new SchematronDiagnosticsParticipant(registry);
 		registry.registerDiagnosticsParticipant(diagnosticsParticipant);
+		metaschemaSchDiagnosticsParticipant = new SchematronMetaschemaSchDiagnosticsParticipant();
+		registry.registerDiagnosticsParticipant(metaschemaSchDiagnosticsParticipant);
 		metaschemaRncURIResolverParticipant = new SchematronMetaschemaResolverParticipant();
 		registry.getResolverExtensionManager().registerResolver(metaschemaRncURIResolverParticipant);
 
@@ -54,6 +57,7 @@ public class SchematronPlugin implements IXMLExtension {
 	@Override
 	public void stop(XMLExtensionsRegistry registry) {
 		registry.unregisterDiagnosticsParticipant(diagnosticsParticipant);
+		registry.unregisterDiagnosticsParticipant(metaschemaSchDiagnosticsParticipant);
 		registry.getResolverExtensionManager().unregisterResolver(metaschemaRncURIResolverParticipant);
 	}
 

--- a/lemminx-schematron/src/main/resources/schemas/schematron.sch
+++ b/lemminx-schematron/src/main/resources/schemas/schematron.sch
@@ -1,0 +1,57 @@
+<!--
+© ISO/IEC 2017
+The following permission notice and disclaimer shall be included in all
+copies of this XML schema ("the Schema"), and derivations of the Schema:
+Permission is hereby granted, free of charge in perpetuity, to any
+person obtaining a copy of the Schema, to use, copy, modify, merge and
+distribute free of charge, copies of the Schema for the purposes of
+developing, implementing, installing and using software based on the
+Schema, and to permit persons to whom the Schema is furnished to do so,
+subject to the following conditions:
+THE SCHEMA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SCHEMA OR THE USE OR
+OTHER DEALINGS IN THE SCHEMA.
+In addition, any modified copy of the Schema shall include the following
+notice:
+THIS SCHEMA HAS BEEN MODIFIED FROM THE SCHEMA DEFINED IN ISO/IEC 19757 3,
+AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD."
+-->
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:lang="en">
+    <sch:title>Schema for Additional Constraints in Schematron</sch:title>
+    <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
+    <sch:p>This schema supplies some constraints in addition to those given in the
+        ISO/IEC 19757 2
+        (RELAX NG Compact Syntax) Schema for Schematron. </sch:p>
+    <sch:pattern>
+        <sch:rule context="sch:active">
+            <sch:assert test="//sch:pattern[@id=current()/@pattern]"> The pattern
+                attribute of the active element shall match the id
+                attribute of a pattern.</sch:assert>
+        </sch:rule>
+        <sch:rule context="sch:pattern[@is-a]">
+            <sch:assert test="//sch:pattern[@abstract='true'][@id=current()/@is-a]"> The
+                is-a attribute of a pattern element shall match 
+                the id attribute of an abstract pattern.
+            </sch:assert>
+        </sch:rule>
+        <sch:rule context="sch:extends">
+            <sch:assert test="//sch:rule[@abstract='true'][@id=current()/@rule]"> The rule
+                attribute of an extends element shall match the id
+                attribute of an abstract rule.
+            </sch:assert>
+        </sch:rule>
+        <sch:rule context="sch:let">
+            <sch:assert
+                test="not(//sch:pattern
+                [@abstract='true']/sch:param[@name=current()/@name])"
+                > A variable name and an abstract pattern parameter should not use the
+                same name.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/lemminx-schematron/src/test/java/com/github/datho7561/SchematronDiagnosticsParticipantTest.java
+++ b/lemminx-schematron/src/test/java/com/github/datho7561/SchematronDiagnosticsParticipantTest.java
@@ -51,7 +51,7 @@ public class SchematronDiagnosticsParticipantTest extends AbstractCacheBasedTest
 				"  <Gender>Female</Gender>\n" + //
 				"</Person>";
 		XMLAssert.testDiagnosticsFor(xml, d(r(1, 1, 1, 7),
-				"If the Title is \"Mr\" then the gender of the person must be \"Male\".", "failed-assert"));
+				"If the Title is \"Mr\" then the gender of the person must be \"Male\".", "schematron-failed-assert"));
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class SchematronDiagnosticsParticipantTest extends AbstractCacheBasedTest
 
 		// diagnostics appear, since the file should be cached
 		XMLAssert.testDiagnosticsFor(xml, d(r(1, 1, 1, 7),
-				"If the Title is \"Mr\" then the gender of the person must be \"Male\".", "failed-assert"));
+				"If the Title is \"Mr\" then the gender of the person must be \"Male\".", "schematron-failed-assert"));
 	}
 
 }

--- a/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaDiagnosticsTest.java
+++ b/lemminx-schematron/src/test/java/com/github/datho7561/SchematronMetaschemaDiagnosticsTest.java
@@ -27,7 +27,24 @@ public class SchematronMetaschemaDiagnosticsTest extends AbstractCacheBasedTest 
 				"  </pattern>\n" + //
 				"</schema>";
 		XMLAssert.testDiagnosticsFor(xml, d(r(3, 5, 3, 16),
-				"element \"rupertGrint\" not allowed anywhere; expected the element end-tag, element \"include\", \"let\", \"p\", \"rule\" or \"title\" or an element from another namespace", "unknown_element"));
+				"element \"rupertGrint\" not allowed anywhere; expected the element end-tag, element \"include\", \"let\", \"p\", \"rule\" or \"title\" or an element from another namespace",
+				"unknown_element"));
+	}
+
+	@Test
+	public void testValidationSchMetaschemaRules() {
+		// test scenario:
+		// is-a is supposed to be my-abstract-schema, but the user mistyped it
+		// TODO: this is a good candidate for completion
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<schema xmlns=\"http://purl.oclc.org/dsdl/schematron\">\n" + //
+				"  <pattern is-a=\"my-abstract-schem\">\n" + //
+				"  </pattern>\n" + //
+				"  <pattern abstract=\"true\" id=\"my-abstract-schema\">\n" + //
+				"  </pattern>\n" + //
+				"</schema>";
+		XMLAssert.testDiagnosticsFor(xml, d(r(2, 3, 2, 10),
+				"The is-a attribute of a pattern element shall match the id attribute of an abstract pattern.", "schematron-failed-assert"));
 	}
 
 }


### PR DESCRIPTION
- Associate all files that define the default namespace as the Schematron namespace with the `schematron.sch` from the schematron GitHub organization
- Change the error code for most messages from `failed-assert` to `schematron-failed-assert`
- Handle namespaces when using the XPath from schxslt to locate the erroneous DOMNode when calculating the range for a Schematron assertion error
  - I don't handle them *well* just *better*

Closes #70