### PR TITLE
Update name.dmaus.schxslt:java to 4.0

### DIFF
--- a/.github/workflows/publish-vscode-ext.yaml
+++ b/.github/workflows/publish-vscode-ext.yaml
@@ -9,10 +9,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           architecture: x64
           cache: maven

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           architecture: x64
           cache: maven

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It uses [schxslt](https://github.com/schxslt/schxslt) and [Saxon-HE](https://sax
 
 ## Requirements
 
-- Java 11+ (JRE or JDK) installed and set up on `PATH`.
+- Java 17+ (JRE or JDK) installed and set up on `PATH`.
 
 ## Usage
 
@@ -61,7 +61,7 @@ args = ["-cp", "/home/davthomp/Documents/lemminx-extensions/lemminx-schematron-0
 
 ### lemminx extension
 
-_Prerequisites_: git, Java 11 or newer
+_Prerequisites_: git, Java 17 or newer
 
 1. Clone this repo.
 2. `cd` into `lemminx-schematron`
@@ -70,7 +70,7 @@ _Prerequisites_: git, Java 11 or newer
 
 ### vscode extension
 
-_Prerequisites_: git, Java 11 or newer, NodeJS 20 or newer, __macOS or Linux__ (the `npm` scripts I wrote are not cross platform)
+_Prerequisites_: git, Java 17 or newer, NodeJS 20 or newer, __macOS or Linux__ (the `npm` scripts I wrote are not cross platform)
 
 1. Clone this repo.
 2. `cd` into `vscode-schematron`

--- a/lemminx-schematron/.gitignore
+++ b/lemminx-schematron/.gitignore
@@ -1,2 +1,6 @@
 /target
 /target/**
+.classpath
+.classpath/**
+.settings
+.settings/**

--- a/lemminx-schematron/pom.xml
+++ b/lemminx-schematron/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <junit.version>5.12.1</junit.version>
     <lemminx.version>0.30.0</lemminx.version>
     <spotbugs.version>4.9.3</spotbugs.version>
@@ -44,7 +44,12 @@
     <dependency>
       <groupId>name.dmaus.schxslt</groupId>
       <artifactId>java</artifactId>
-      <version>3.1.1</version>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>name.dmaus.schxslt</groupId>
+      <artifactId>schxslt</artifactId>
+      <version>1.8.6</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>

--- a/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronDocumentValidator.java
+++ b/lemminx-schematron/src/main/java/com/github/datho7561/schematron/SchematronDocumentValidator.java
@@ -46,6 +46,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import name.dmaus.schxslt.Result;
 import name.dmaus.schxslt.Schematron;
 import name.dmaus.schxslt.SchematronException;
+import name.dmaus.schxslt.adapter.SchXslt;
 
 /**
  * Validates an XML document using Schematron schemas
@@ -90,7 +91,7 @@ public class SchematronDocumentValidator {
 		for (File schema : schemaFiles) {
 			Schematron schematron = null;
 			try {
-				schematron = new Schematron(new StreamSource(schema));
+				schematron = new Schematron(new SchXslt(), new StreamSource(schema));
 			} catch (RuntimeException | SchematronException e) {
 				// FIXME: Use the path to the schema
 				LOGGER.log(Level.WARNING, "Error while processing the schema", e);

--- a/vscode-schematron/.vscode/extensions.json
+++ b/vscode-schematron/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-  // See http://go.microsoft.com/fwlink/?LinkId=827846
-  // for the documentation about the extensions.json format
-  "recommendations": ["dbaeumer.vscode-eslint", "connor4312.esbuild-problem-matchers", "ms-vscode.extension-test-runner"]
+  "recommendations": ["dbaeumer.vscode-eslint", "ms-vscode.extension-test-runner"]
 }

--- a/vscode-schematron/README.md
+++ b/vscode-schematron/README.md
@@ -59,7 +59,7 @@ You will get validation based on the Schematron rules:
 ## Requirements
 
 - Red Hat's vscode-xml extension
-- Java 11 or newer (it doesn't work with the binary mode)
+- Java 17 or newer (it doesn't work with the binary mode)
 
 ## Known Issues
 

--- a/vscode-schematron/tsconfig.json
+++ b/vscode-schematron/tsconfig.json
@@ -5,6 +5,7 @@
 		"lib": [
 			"ES2022"
 		],
+		"skipLibCheck": true,
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true   /* enable all strict type-checking options */


### PR DESCRIPTION
Update to API changes:
- require Java 17
- pass `Adapter` as a parameter to the `Schematron` constructor
- add name.dmaus.schxslt:schxslt as a dependency (either that or schxslt2 is required, I found v1 required less effort to get working)

Closes #78 