### PR TITLE
Fix publishing `.vsix` for GitHub Releases

### DIFF
--- a/.github/workflows/publish-vscode-ext.yaml
+++ b/.github/workflows/publish-vscode-ext.yaml
@@ -40,4 +40,4 @@ jobs:
           automatic_release_tag: "${{ env.EXT_VERSION }}"
           draft: true
           files: |
-            *.vsix
+            vscode-schematron/*.vsix


### PR DESCRIPTION
- I forgot it was in a subfolder