### PR TITLE
Upversion lemminx to 0.31.0

### DIFF
--- a/lemminx-schematron/pom.xml
+++ b/lemminx-schematron/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <junit.version>5.12.2</junit.version>
-    <lemminx.version>0.30.1</lemminx.version>
+    <lemminx.version>0.31.0</lemminx.version>
     <spotbugs.version>4.9.3</spotbugs.version>
   </properties>
 


### PR DESCRIPTION
Important, since lemminx 0.30.1 has disappeared due a storage failure at Eclipse.